### PR TITLE
Add sleep in benchmark loop

### DIFF
--- a/benchmark/Helper.cs
+++ b/benchmark/Helper.cs
@@ -14,7 +14,7 @@ public static class Helper
          return $"{Math.Round(duration.TotalSeconds, 3)} s";
     }
 
-        public static string Humanize(this float nb, string unit = "")
+    public static string Humanize(this float nb, string unit = "")
     {
         return Humanize((double) nb, unit);
     }

--- a/benchmark/Helper.cs
+++ b/benchmark/Helper.cs
@@ -1,20 +1,5 @@
 public static class Helper
 {
-    public static void Deconstruct<T>(this T[] arr, out T first, out T second, out T third)
-    {
-        first = arr[0];
-        second = arr[1];
-        third = arr[2];
-    }
-
-    public static void Deconstruct<T>(this T[] arr, out T first, out T second, out T third, out T fourth)
-    {
-        first = arr[0];
-        second = arr[1];
-        third = arr[2];
-        fourth = arr[3];
-    }
-
     public static string Humanize(this TimeSpan duration)
     {
         if(duration.TotalMicroseconds < 1000) 

--- a/benchmark/Helper.cs
+++ b/benchmark/Helper.cs
@@ -1,5 +1,12 @@
 public static class Helper
 {
+    public static void Deconstruct<T>(this T[] arr, out T first, out T second, out T third)
+    {
+        first = arr[0];
+        second = arr[1];
+        third = arr[2];
+    }
+    
     public static string Humanize(this TimeSpan duration)
     {
         if(duration.TotalMicroseconds < 1000) 

--- a/benchmark/Program.cs
+++ b/benchmark/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Drawing;
+using System.Threading;
 using BetterConsoles.Tables;
 using BetterConsoles.Tables.Configuration;
 using BetterConsoles.Tables.Models;
@@ -51,6 +52,7 @@ foreach(var dataset in datasets)
             while(!process.HasExited)
             {
                 memory = process.PeakWorkingSet64;
+                Thread.Sleep(1);
             }
 
             process.WaitForExit();


### PR DESCRIPTION
Cette PR doit être vue comme venant en sus de #2 

L'idée d'ajouter un `Sleep` à la boucle de benchmarking est liée au fait que, dans la boucle de benchmarking (quand le process de benchmarking attend la fin du process benchmarké),  j'ai l'impression que le processus de benchmarking monopolisera un CPU du fait que la boucle en question n'a aucune condition d'attente.

Après, suivant les objectifs du benchmark, cela n'est pas nécessairement dramatique.